### PR TITLE
Fix error from basename when directly source in interactive shell

### DIFF
--- a/shml.sh
+++ b/shml.sh
@@ -197,7 +197,7 @@ function icon {
 
 # Usage / Examples
 ##
-if [[ "`basename $0`" = "shml.sh" ]]; then
+if [[ "$0" != "-bash" ]] && [[ "`basename $0`" = "shml.sh" ]]; then
 I=2
 echo -e "
 $(a bold 'SHML Usage / Help')


### PR DESCRIPTION
The part for example will result the following error:

```
$ echo $0
-bash
$ source shml.sh
basename: invalid option -- 'b'
Try 'basename --help' for more information.
```

Although, the main code of shml still is sourced correct and useable, even `basename` spits an error, but it might be better for newcomer like me to try it out directly in interactive shell instead of making a script to test out.
