### PR TITLE
Better way of detecting whether script is sourced or not.

### DIFF
--- a/shml.sh
+++ b/shml.sh
@@ -280,7 +280,7 @@ function e {
 
 # Usage / Examples
 ##
-if [[ "$(basename -- "$0")" = "shml.sh" ]]; then
+if [ "$0" == "$BASH_SOURCE" ]; then
 I=2
 echo -e "
 


### PR DESCRIPTION
Now it works for any filename, e.g. `shml` *or* `shml.sh`.