### PR TITLE
Style color and attribute example boxes

### DIFF
--- a/_includes/attributes.md
+++ b/_includes/attributes.md
@@ -6,7 +6,11 @@ The `attribute` method lets you stylize your text in 5 different ways.
 
 ### Arguments
 
-`bold` `dim` `underline` `invert` `hidden`
+<code><span style="font-weight: bold">bold</span></code>
+<code><span style="color: gray">dim</span></code>
+<code><span style="text-decoration: underline">underline</span></code>
+<code><span style="color: black; background-color: white">invert</span></code>
+`hidden`
 
 #### Termination
 

--- a/_includes/background.md
+++ b/_includes/background.md
@@ -7,7 +7,7 @@ To set the background color of any string or object you need to call the `bgcolo
 
 #### Colors
 
-Fifteen different colors to choose from:
+Fifteen different colors to choose from:<br>
 <code class="color-box-black"       >black</code>
 <code class="color-box-red"         >red</code>
 <code class="color-box-green"       >green</code>

--- a/_includes/background.md
+++ b/_includes/background.md
@@ -8,10 +8,21 @@ To set the background color of any string or object you need to call the `bgcolo
 #### Colors
 
 Fifteen different colors to choose from:
-
-`black` `red` `green` `yellow` `blue` `magenta` `cyan` `gray`
-`white` `darkgray` `lightgreen` `lightyellow` `lightblue`
-`lightmagenta` `lightcyan`
+<code class="color-box-black"       >black</code>
+<code class="color-box-red"         >red</code>
+<code class="color-box-green"       >green</code>
+<code class="color-box-yellow"      >yellow</code>
+<code class="color-box-blue"        >blue</code>
+<code class="color-box-magenta"     >magenta</code>
+<code class="color-box-cyan"       >cyan</code>
+<code class="color-box-gray"        >gray</code>
+<code class="color-box-white"       >white</code>
+<code class="color-box-darkgray"    >darkgray</code>
+<code class="color-box-lightgreen"  >lightgreen</code>
+<code class="color-box-lightyellow" >lightyellow</code>
+<code class="color-box-lightblue"   >lightblue</code>
+<code class="color-box-lightmagenta">lightmagenta</code>
+<code class="color-box-lightcyan"   >lightcyan</code>
 
 #### Termination
 

--- a/_includes/foreground.md
+++ b/_includes/foreground.md
@@ -9,11 +9,21 @@ To set the foreground color of any string or object you need to call the `fgcolo
 #### Colors
 
 Fifteen different colors to choose from:
-
-`black` `red` `green` `yellow` `blue` `magenta` `cyan` `gray`
-`white` `darkgray` `lightgreen` `lightyellow` `lightblue`
-`lightmagenta` `lightcyan`
-
+<code class="color-box-black"       >black</code>
+<code class="color-box-red"         >red</code>
+<code class="color-box-green"       >green</code>
+<code class="color-box-yellow"      >yellow</code>
+<code class="color-box-blue"        >blue</code>
+<code class="color-box-magenta"     >magenta</code>
+<code class="color-box-cyan"       >cyan</code>
+<code class="color-box-gray"        >gray</code>
+<code class="color-box-white"       >white</code>
+<code class="color-box-darkgray"    >darkgray</code>
+<code class="color-box-lightgreen"  >lightgreen</code>
+<code class="color-box-lightyellow" >lightyellow</code>
+<code class="color-box-lightblue"   >lightblue</code>
+<code class="color-box-lightmagenta">lightmagenta</code>
+<code class="color-box-lightcyan"   >lightcyan</code>
 
 #### Termination
 Following a string or object you must terminate the `fgcolor` method to ensure color doesn't bleed.  You can use any of the following termination arguments:

--- a/_includes/foreground.md
+++ b/_includes/foreground.md
@@ -8,7 +8,7 @@ To set the foreground color of any string or object you need to call the `fgcolo
 
 #### Colors
 
-Fifteen different colors to choose from:
+Fifteen different colors to choose from:<br>
 <code class="color-box-black"       >black</code>
 <code class="color-box-red"         >red</code>
 <code class="color-box-green"       >green</code>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,6 +18,7 @@
   <link rel="stylesheet" href="{{ site.baseurl }}public/css/poole.css">
   <link rel="stylesheet" href="{{ site.baseurl }}public/css/syntax.css">
   <link rel="stylesheet" href="{{ site.baseurl }}public/css/hyde.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}public/css/style.css">
   <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
 
   <!-- Icons -->

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,0 +1,25 @@
+/**
+ * Demo color boxes.
+ */
+code.color-box-black {
+    color: black;
+    background-color: white;
+
+    padding: 2px;
+    border: 2px solid black;
+}
+
+code.color-box-red          { color: #cc0000; }
+code.color-box-green        { color: #4e9a06; }
+code.color-box-yellow       { color: #c4a000; }
+code.color-box-blue         { color: #3465a4; }
+code.color-box-magenta      { color: #75507b; }
+code.color-box-cyan         { color: #0b939b; }
+code.color-box-gray         { color: #555753; }
+code.color-box-white        { color: #EEEEEC; }
+code.color-box-darkgray     { color: #555753; }
+code.color-box-lightgreen   { color: #8ae234; }
+code.color-box-lightyellow  { color: #fce94f; }
+code.color-box-lightblue    { color: #729fcf; }
+code.color-box-lightmagenta { color: #ad7fa8; }
+code.color-box-lightcyan    { color: #00f5e9; }


### PR DESCRIPTION
Edit `public/css/style.css` to modify the color/decoration of each box to fit your colorscheme if necessary.

![attributes](https://cloud.githubusercontent.com/assets/4251257/10435514/5bb172b2-70d5-11e5-8e9e-4d420ec0fe78.png)
![colors](https://cloud.githubusercontent.com/assets/4251257/10435730/87208504-70d6-11e5-9084-638184ab5fae.png)