### PR TITLE
test seperation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ clean:
 	rm test/shunt.sh
 
 test/shunt.sh:
-	cd test && curl -L https://raw.github.com/odb/shunt/master/install.sh | bash -s local
+	cd test && curl -L https://raw.githubusercontent.com/odb/shunt/master/install.sh | bash -s local
 
 BRANCH=master
 

--- a/test/attributes_tests.sh
+++ b/test/attributes_tests.sh
@@ -1,0 +1,17 @@
+function test_attributes {
+  # Attribute
+  ##
+  assert_equal "$(attribute bold)foo$(attribute end)" \
+          "$(echo -e '\033[1mfoo\033[0m')" \
+          'should return bold text and end'
+
+  assert_equal "$(attribute dim)foo$(attribute)" \
+          "$(echo -e '\033[2mfoo\033[0m')" \
+          'should return dim text and end'
+
+  # Attribute - a alias
+  ##
+  assert_equal "$(a bold)foo$(a)" \
+          "$(echo -e '\033[1mfoo\033[0m')" \
+          'should return bold text and end'
+}

--- a/test/color_tests.sh
+++ b/test/color_tests.sh
@@ -1,0 +1,64 @@
+function test_color_background {
+  # Background
+  ##
+  assert_equal "$(background white 'foo')" \
+          "$(echo -e '\033[107mfoo\033[49m')" \
+          "should return white background, text and end color"
+
+  assert_equal "$(background darkgray 'foo')" \
+          "$(echo -e '\033[100mfoo\033[49m')" \
+          "should return black background, text and end color"
+
+  assert_equal "$(background black 'foo')" \
+          "$(echo -e '\033[40mfoo\033[49m')" \
+          "should return black background, text and end color"
+
+  assert_equal "$(background white)foo$(background)" \
+          "$(echo -e '\033[107mfoo\033[49m')" \
+          'should return white background, text and end color'
+
+  assert_equal "$(background red)foo$(background end)" \
+          "$(echo -e '\033[41mfoo\033[49m')" \
+          'should return red background, text and end color'
+
+  # Background - bg alias
+  ##
+  assert_equal "$(bg 'white' 'foo')" \
+          "$(echo -e '\033[107mfoo\033[49m')" \
+          "should return white background, text and end color"
+}
+
+function test_color_foreground {
+  # Foreground - color
+  ##
+  assert_equal "$(color black 'foo')" \
+          "$(echo -e '\033[30mfoo\033[39m')" \
+          "should return black foreground, text and end color"
+
+  assert_equal "$(color darkgray 'foo')" \
+          "$(echo -e '\033[91mfoo\033[39m')" \
+          "should return black foreground, text and end color"
+
+  assert_equal "$(color white 'foo')" \
+          "$(echo -e '\033[97mfoo\033[39m')" \
+          "should return white foreground, text and end color"
+
+  assert_equal "$(color e4e4e4 'foo')" \
+          "$(echo -e '\033[90mfoo\033[39m')" \
+          "should return e4e4e4 foreground, text and end color"
+
+  assert_equal "$(color white)foo$(color)" \
+          "$(echo -e '\033[97mfoo\033[39m')" \
+          'should return white foreground, text and end color'
+
+  assert_equal "$(color red)foo$(color 'end')" \
+          "$(echo -e '\033[31mfoo\033[39m')" \
+          'should return red foreground, text and end color'
+
+  # Foreground - c alias
+  ##
+  assert_equal "$(c white 'foo')" \
+          "$(echo -e '\033[97mfoo\033[39m')" \
+          "should return white foreground, text and end color"
+}
+

--- a/test/elements_tests.sh
+++ b/test/elements_tests.sh
@@ -1,0 +1,20 @@
+function test_elements {
+  # Elements
+  ##
+  assert_equal "$(br)" "$(echo -ne "\n\r")" "should line break"
+
+  assert_equal "$(tab)" "$(echo -e '\t')" "should tab"
+
+  assert_equal "$(indent)" "    " "should tab"
+  assert_equal "$(indent 2)" "  " "should tab"
+  assert_equal "$(i 2)" "  " "should tab"
+
+  assert_equal "$(hr)" "------------------------------------------------------------" \
+                "should draw default hr"
+
+  assert_equal "$(hr 4)" "----" \
+                "should draw hr 4 wide"
+
+  assert_equal "$(hr '.' 4)" "...." \
+                "should draw hr 4 wide with char"
+}

--- a/test/emojis_tests.sh
+++ b/test/emojis_tests.sh
@@ -1,0 +1,6 @@
+function test_emojis {
+  # Emojis
+  ##
+  assert_equal "$(emoji brew)" '🍺' \
+                "should draw beer"
+}

--- a/test/entities_tests.sh
+++ b/test/entities_tests.sh
@@ -1,0 +1,6 @@
+function test_entities {
+  # Entities
+  ##
+  assert_equal "$(entity lt)" '<' \
+                "should draw lt"
+}

--- a/test/icons_tests.sh
+++ b/test/icons_tests.sh
@@ -1,0 +1,9 @@
+function test_icons {
+  # Icons
+  ##
+  assert_equal "$(icon smile)" '☺' \
+                "should draw smile"
+
+  assert_equal "$(icon lt)" '<' \
+                "should draw lt"
+}

--- a/test/tests.sh
+++ b/test/tests.sh
@@ -100,7 +100,7 @@ function run_tests {
   assert_equal "$(hr '.' 4)" "...." \
                 "should draw hr 4 wide with char"
 
-  # Icons / Entities
+  # Icons / Entities / Emojis
   ##
   assert_equal "$(icon smile)" '☺' \
                 "should draw smile"
@@ -111,6 +111,8 @@ function run_tests {
   assert_equal "$(entity lt)" '<' \
                 "should draw lt"
 
+  assert_equal "$(emoji brew)" '🍺' \
+                "should draw beer"
   # Mixed
   ##
   assert_equal "$(bg white)$(c black foo)$(bg)" \

--- a/test/tests.sh
+++ b/test/tests.sh
@@ -2,117 +2,22 @@
 
 source ./shml.sh
 
+# source all tests files
+for f in ./test/*_tests.sh; do source $f; done
+
 function run_tests {
 ####################################################
 # Tests go here.
 ####################################################
 
-  # Foreground - color
-  ##
-  assert_equal "$(color black 'foo')" \
-          "$(echo -e '\033[30mfoo\033[39m')" \
-          "should return black foreground, text and end color"
+  test_attributes
+  test_color_background
+  test_color_foreground
+  test_elements
+  test_emojis
+  test_entities
+  test_icons
 
-  assert_equal "$(color darkgray 'foo')" \
-          "$(echo -e '\033[91mfoo\033[39m')" \
-          "should return black foreground, text and end color"
-
-  assert_equal "$(color white 'foo')" \
-          "$(echo -e '\033[97mfoo\033[39m')" \
-          "should return white foreground, text and end color"
-
-  assert_equal "$(color e4e4e4 'foo')" \
-          "$(echo -e '\033[90mfoo\033[39m')" \
-          "should return e4e4e4 foreground, text and end color"
-
-  assert_equal "$(color white)foo$(color)" \
-          "$(echo -e '\033[97mfoo\033[39m')" \
-          'should return white foreground, text and end color'
-
-  assert_equal "$(color red)foo$(color 'end')" \
-          "$(echo -e '\033[31mfoo\033[39m')" \
-          'should return red foreground, text and end color'
-
-  # Foreground - c alias
-  ##
-  assert_equal "$(c white 'foo')" \
-          "$(echo -e '\033[97mfoo\033[39m')" \
-          "should return white foreground, text and end color"
-
-  # Background
-  ##
-  assert_equal "$(background white 'foo')" \
-          "$(echo -e '\033[107mfoo\033[49m')" \
-          "should return white background, text and end color"
-
-  assert_equal "$(background darkgray 'foo')" \
-          "$(echo -e '\033[100mfoo\033[49m')" \
-          "should return black background, text and end color"
-
-  assert_equal "$(background black 'foo')" \
-          "$(echo -e '\033[40mfoo\033[49m')" \
-          "should return black background, text and end color"
-
-  assert_equal "$(background white)foo$(background)" \
-          "$(echo -e '\033[107mfoo\033[49m')" \
-          'should return white background, text and end color'
-
-  assert_equal "$(background red)foo$(background end)" \
-          "$(echo -e '\033[41mfoo\033[49m')" \
-          'should return red background, text and end color'
-
-  # Background - bg alias
-  ##
-  assert_equal "$(bg 'white' 'foo')" \
-          "$(echo -e '\033[107mfoo\033[49m')" \
-          "should return white background, text and end color"
-
-  # Attribute
-  ##
-  assert_equal "$(attribute bold)foo$(attribute end)" \
-          "$(echo -e '\033[1mfoo\033[0m')" \
-          'should return bold text and end'
-
-  assert_equal "$(attribute dim)foo$(attribute)" \
-          "$(echo -e '\033[2mfoo\033[0m')" \
-          'should return dim text and end'
-
-  # Attribute - a alias
-  ##
-  assert_equal "$(a bold)foo$(a)" \
-          "$(echo -e '\033[1mfoo\033[0m')" \
-          'should return bold text and end'
-
-  # Elements
-  ##
-  assert_equal "$(br)" "$(echo -ne "\n\r")" "should line break"
-
-  assert_equal "$(tab)" "$(echo -e '\t')" "should tab"
-
-  assert_equal "$(indent)" "    " "should indent"
-
-  assert_equal "$(hr)" "------------------------------------------------------------" \
-                "should draw default hr"
-
-  assert_equal "$(hr 4)" "----" \
-                "should draw hr 4 wide"
-
-  assert_equal "$(hr '.' 4)" "...." \
-                "should draw hr 4 wide with char"
-
-  # Icons / Entities / Emojis
-  ##
-  assert_equal "$(icon smile)" '☺' \
-                "should draw smile"
-
-  assert_equal "$(icon lt)" '<' \
-                "should draw lt"
-
-  assert_equal "$(entity lt)" '<' \
-                "should draw lt"
-
-  assert_equal "$(emoji brew)" '🍺' \
-                "should draw beer"
   # Mixed
   ##
   assert_equal "$(bg white)$(c black foo)$(bg)" \


### PR DESCRIPTION
@jdorfman The purpose of this is to make it easier and cleaner to add tests in the future. Thoughts?

**CHANGELOG notes:**

- Updated `shunt` fetch path to use new github cdn.
- Breaking out tests in to separate files/functions and adding support for source `./test/*_tests.sh` files automatically.