### PR TITLE
fixing int checking to ensure that indent always works, readding test

### DIFF
--- a/shml.sh
+++ b/shml.sh
@@ -158,8 +158,9 @@ tab() {
 
 indent() {
   local __len=4
+  local __int='^[0-9]+$'
   if test "$1"; then
-    if [[ $1 =~ $re ]] ; then
+    if [[ $1 =~ $__int ]] ; then
       __len=$1
     fi
   fi
@@ -175,9 +176,9 @@ i() {
 hr() {
   local __len=60
   local __char='-'
+  local __int='^[0-9]+$'
   if ! test "$2"; then
-    re='^[0-9]+$'
-    if [[ $1 =~ $re ]] ; then
+    if [[ $1 =~ $__int ]] ; then
       __len=$1
     elif test "$1"; then
       __char=$1


### PR DESCRIPTION
Noticed that the `indent 2` test was removed, guessing it doesn't work in all cases. This change should fix that. Re-added the test.

~~Note: This should be rebased with master once #19  is merged. I can handle that, just remind me. ;-)~~ **DONE**

cc @jdorfman 