### PR TITLE
Fix bug about Controlling the Prompt.

### DIFF
--- a/shml.sh
+++ b/shml.sh
@@ -130,6 +130,8 @@ dialog() {
 # Foreground (Text)
 ##
 fgcolor() {
+  local __seq_start='\['
+  local __seq_end='\]'
   local __end='\033[39m'
   local __color=$__end # end by default
   case "$1" in
@@ -151,9 +153,9 @@ fgcolor() {
     white|ffffff|fff)    __color='\033[97m';;
   esac
   if test "$2"; then
-    echo -en "$__color$2$__end"
+    echo -en "$__seq_start$__color$2$__end$__seq_end"
   else
-    echo -en "$__color"
+    echo -en "$__seq_start$__color$__seq_end"
   fi
 }
 
@@ -174,6 +176,8 @@ c() {
 # Background
 ##
 bgcolor() {
+  local __seq_start='\['
+  local __seq_end='\]'
   local __end='\033[49m'
   local __color=$__end # end by default
   case "$1" in
@@ -197,9 +201,9 @@ bgcolor() {
   esac
 
   if test "$2"; then
-    echo -en "$__color$2$__end"
+    echo -en "$__seq_start$__color$2$__end$__seq_end"
   else
-    echo -en "$__color"
+    echo -en "$__seq_start$__color$__seq_end"
   fi
 }
 


### PR DESCRIPTION
Must enclosed not-printable sequences in \[ and \] when use shml in prompt.
Or will overwrite the current line of screen and hard to see.